### PR TITLE
Performance: Optimize coef cache in SincInterpolator

### DIFF
--- a/core/src/main/java/edu/mines/jtk/dsp/KaiserWindow.java
+++ b/core/src/main/java/edu/mines/jtk/dsp/KaiserWindow.java
@@ -147,12 +147,12 @@ public class KaiserWindow {
   ///////////////////////////////////////////////////////////////////////////
   // private
 
-  private double _error;
-  private double _width;
-  private double _length;
-  private double _alpha;
-  private double _scale;
-  private double _xxmax;
+  private final double _error;
+  private final double _width;
+  private final double _length;
+  private final double _alpha;
+  private final double _scale;
+  private final double _xxmax;
 
   private KaiserWindow(double error, double width, double length) {
     _error = error;


### PR DESCRIPTION
Eliminate excess synchronization in `SincInterpolator` by using `ConcurrentHashMap` for the coef cache.

With this change, cache readers are lock-free, and writers contend on locks less frequently, due to lock striping approach leveraged by `ConcurrentHashMap`.

Since memory barriers related to `synchronized` block exit are gone, classes like `Design`, `Table`, `KaiserWindow` should safely publish their state on construction, by having the `final` modifier on fields.