### PR TITLE
Fix index overflow in quickPartition methods.

### DIFF
--- a/core/src/main/java/edu/mines/jtk/util/ArrayMath.java
+++ b/core/src/main/java/edu/mines/jtk/util/ArrayMath.java
@@ -9253,7 +9253,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9297,7 +9297,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9404,7 +9404,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9448,7 +9448,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9555,7 +9555,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9599,7 +9599,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9706,7 +9706,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9750,7 +9750,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9857,7 +9857,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -9901,7 +9901,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -10008,7 +10008,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;
@@ -10052,7 +10052,7 @@ public class ArrayMath {
     int p = m[0];
     int q = m[1];
     int n = q-p+1;
-    int k = (p+q)/2;
+    int k = (int) (((long) p + (long) q)/2L);
     if (n>NSMALL_SORT) {
       int j = p;
       int l = q;


### PR DESCRIPTION
When sorting a large array where the length is more than half the maximum integer value, one of the computed indices in quickPartition may overflow, which can lead to a negative array index.   This patch fixes the overflow issue using longs to compute the index value.